### PR TITLE
Adding intersection observer to blocks that heavily use query index to make things faster.

### DIFF
--- a/blocks/post-cards/post-cards.js
+++ b/blocks/post-cards/post-cards.js
@@ -215,6 +215,9 @@ async function loadBlock(block) {
   block.append(moreContainer);
 
   showHideMore(grid, moreContainer);
+  // post a message indicating cards are loaded, this triggers the tags block to load
+  // see comment there for more details
+  window.postMessage({ postCardsLoaded: true }, window.location.origin);
 }
 
 /**

--- a/blocks/tags/tags.js
+++ b/blocks/tags/tags.js
@@ -60,11 +60,6 @@ function getTagsLinks(tags, limit) {
 async function loadBlock(block) {
   const conf = readBlockConfig(block);
   const { filter } = conf;
-  const isAll = block.classList.contains('all');
-  while (!window.keysight.postData.allLoaded) {
-    // eslint-disable-next-line no-await-in-loop
-    await loadPosts(true);
-  }
 
   const applicableFilter = filter || 'auto';
   const posts = await getPosts(applicableFilter, -1);
@@ -96,6 +91,7 @@ async function loadBlock(block) {
     return true;
   });
   tagsAsArray.sort((a, b) => b.count - a.count);
+  const isAll = block.classList.contains('all');
   block.innerHTML = '';
   block.append(getTagsLinks(tagsAsArray, isAll ? -1 : 15));
   if (isAll) {
@@ -107,12 +103,35 @@ async function loadBlock(block) {
  * decorates the block
  * @param {Element} block The featured posts block element
  */
-export default function decorate(block) {
-  const observer = new IntersectionObserver((entries) => {
-    if (entries.some((e) => e.isIntersecting)) {
-      observer.disconnect();
+export default async function decorate(block) {
+  const isAll = block.classList.contains('all');
+  if (isAll) {
+    // if it's all tags, force load all the posts then use those to collect the tags
+    while (!window.keysight.postData.allLoaded) {
+      // eslint-disable-next-line no-await-in-loop
+      await loadPosts(true);
+    }
+    loadBlock(block);
+  } else {
+    // find a post cards block, if it exists wait to load tags til that loads, else just load
+    const postCards = document.querySelector('.block.post-cards');
+    if (postCards) {
+      /*
+        The posts, which are used to derive the tags, are a shared array
+        This helps avoid timing conflict, such that if there are post cards in the page
+        we wait til that finishes loading, which may require loading additional posts from
+        the query index.
+
+        Once that completes, this block can simply collect tags from the posts already loaded
+        rather than potentially having to load more posts on it's own to find all the required tags.
+      */
+      window.addEventListener('message', (msg) => {
+        if (msg.origin === window.location.origin && msg.data && msg.data.postCardsLoaded) {
+          loadBlock(block);
+        }
+      });
+    } else {
       loadBlock(block);
     }
-  });
-  observer.observe(block);
+  }
 }


### PR DESCRIPTION
Adding

Test URLs:
- Before: https://main--blogs-keysight--hlxsites.hlx.page/
- After: https://delay-load--blogs-keysight--hlxsites.hlx.page/
- After: https://delay-load--blogs-keysight--hlxsites.hlx.page/tech/sim-des/
- After: https://delay-load--blogs-keysight--hlxsites.hlx.page/tech/nwvs/2023/01/10/a-golfers-guide-to-not-buying-security
- After: https://delay-load--blogs-keysight--hlxsites.hlx.page/tag-matches?tag=Test%20as%20a%20Service
- After: https://delay-load--blogs-keysight--hlxsites.hlx.page/all-tags
