### PR TITLE
78 // Update getNavPages with ffetch

### DIFF
--- a/blogs/blocks/post-sidebar/post-sidebar.js
+++ b/blogs/blocks/post-sidebar/post-sidebar.js
@@ -8,8 +8,8 @@ import {
 } from '../../scripts/lib-franklin.js';
 import {
   createElement,
-  getNavPages,
 } from '../../scripts/scripts.js';
+import ffetch from '../../scripts/ffetch.js';
 
 const socialIcons = ['facebook', 'twitter', 'linkedin', 'email'];
 const tags = getMetadata('article:tag').split(', ');
@@ -86,9 +86,9 @@ export default async function decorate(block) {
   let authorName;
   let authorTitle;
   let authorUrl;
-  const navPages = await getNavPages();
+  const authorPage = await ffetch('/blogs/query-index.json').sheet('nav')
+    .filter((page) => page.title.toLowerCase() === getMetadata('author')?.toLowerCase()).first();
 
-  const authorPage = navPages.find((page) => page.title.toLowerCase() === getMetadata('author')?.toLowerCase());
   if (authorPage) {
     authorImage = authorPage.image;
     authorName = authorPage.title;

--- a/blogs/blocks/search-results/search-results.js
+++ b/blogs/blocks/search-results/search-results.js
@@ -9,27 +9,25 @@ import {
   loadPosts,
   splitTags,
   createElement,
-  getNavPages,
 } from '../../scripts/scripts.js';
+import ffetch from '../../scripts/ffetch.js';
 
 const pageSize = 10;
 const initLoad = pageSize * 2;
 
-function getAuthorLink(post, navPages) {
+async function getAuthorLink(post) {
   const { author } = post;
   const notLink = createElement('span');
   notLink.innerText = `${author}`;
 
-  try {
-    const authorPage = navPages.find((page) => page.title === author);
-    if (authorPage) {
-      const link = createElement('a');
-      link.href = authorPage.path;
-      link.innerText = `${author}`;
-      return link;
-    }
-  } finally {
-    // no op, just fall through to return default value
+  const authorPage = await ffetch('/blogs/query-index.json').sheet('nav')
+    .filter((page) => page.title.toLowerCase() === author?.toLowerCase()).first();
+
+  if (authorPage) {
+    const link = createElement('a');
+    link.href = authorPage.path;
+    link.innerText = `${author}`;
+    return link;
   }
 
   return notLink;
@@ -88,7 +86,7 @@ async function executeSearch(q) {
   return results;
 }
 
-function buildPostCard(post, index, navPagesPromise) {
+function buildPostCard(post, index) {
   const classes = ['post-card'];
   if (index >= pageSize) {
     classes.push('hidden');
@@ -124,8 +122,9 @@ function buildPostCard(post, index, navPagesPromise) {
       <p class="card-author"><span class="author-text">${post.author}</span><span class="card-date">${postDateStr}</span></p>
     </div>
   `;
-  navPagesPromise.then((navPages) => {
-    const authorLink = getAuthorLink(post, navPages);
+
+  const authorLinkPromise = getAuthorLink(post);
+  authorLinkPromise.then((authorLink) => {
     if (authorLink) {
       postCard.querySelector('.card-author').replaceChild(authorLink, postCard.querySelector('.card-author .author-text'));
     }
@@ -158,9 +157,8 @@ export default async function decorate(block) {
   }
 
   let counter = 0;
-  const navPagesPromise = getNavPages();
   for (let i = 0; i < primaryPosts.length; i += 1) {
-    const postCard = buildPostCard(primaryPosts[i].post, counter, navPagesPromise);
+    const postCard = buildPostCard(primaryPosts[i].post, counter);
     grid.append(postCard);
     counter += 1;
   }
@@ -170,7 +168,7 @@ export default async function decorate(block) {
     if (!deferredLoaded) {
       deferredLoaded = true;
       for (let i = 0; i < deferredPosts.length; i += 1) {
-        const postCard = buildPostCard(deferredPosts[i].post, counter, navPagesPromise);
+        const postCard = buildPostCard(deferredPosts[i].post, counter);
         grid.append(postCard);
         counter += 1;
       }


### PR DESCRIPTION
See #78 

Notes:
- Replaced getNavPages calls with ffetch on post-cards, search, and post sidebar
- getNavPages() util in scripts.js is still referenced by post.js

Test URLs:

- Before: https://main--blogs-keysight--hlxsites.hlx.live/blogs/
- After: https://issues-78-post-card-ffetch--blogs-keysight--hlxsites.hlx.live/blogs/