### PR TITLE
refactor path variables

### DIFF
--- a/.github/ci/generate-news-feed.js
+++ b/.github/ci/generate-news-feed.js
@@ -1,9 +1,9 @@
 import { Feed } from 'feed';
 import fs from 'fs';
 
-const endpoint = 'https://www.keysight.com/blogs/query-index.json';
-const feedInfoEndpoint = 'https://www.keysight.com/blogs/feed-info.json';
-const targetDirectory = '../../blogs/rss';
+const endpoint = process.argv[2];
+const feedInfoEndpoint = process.argv[3];
+const targetDirectory = process.argv[4];
 const targetFile = `${targetDirectory}/feed.xml`;
 const limit = 1000;
 

--- a/.github/workflows/generate-atom-news-feed.yaml
+++ b/.github/workflows/generate-atom-news-feed.yaml
@@ -12,6 +12,11 @@ on:
       - '.github/ci/**'
       - '.github/workflows/generate-atom-news-feed.yaml'
 
+env:
+  ENDPOINT: "https://www.keysight.com/blogs/query-index.json"
+  FEEDINFOENDPOINT: "https://www.keysight.com/blogs/feed-info.json"
+  TARGETDIRECTORY: "../../blogs/rss"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,7 +43,7 @@ jobs:
 
     - name: Generate Feed
       working-directory: ./.github/ci
-      run:  node generate-news-feed.js
+      run:  node generate-news-feed.js ${{ env.ENDPOINT }} ${{ env.FEEDINFOENDPOINT }} ${{ env.TARGETDIRECTORY }}
 
     - name: Commit and push changes
       uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #86 

Test URLs:

- Before: https://main--blogs-keysight--hlxsites.hlx.live/blogs/
- After: https://rss-variables--blogs-keysight--hlxsites.hlx.live/blogs/

This removes the path assignments out of the JS and into the environment variables of the Github Actions Workflow.
