### PR TITLE
Only show valid Franklin tags - sidebar, post, search, and tags

### DIFF
--- a/blogs/blocks/post-cards/post-cards.js
+++ b/blogs/blocks/post-cards/post-cards.js
@@ -78,10 +78,8 @@ async function getTagsLinks(post) {
       const link = createElement('a');
       link.innerText = `#${tag}`;
       link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag)}`;
-
       item.append(link);
       list.append(item);
-
     });
     return list;
   }

--- a/blogs/blocks/post-cards/post-cards.js
+++ b/blogs/blocks/post-cards/post-cards.js
@@ -71,9 +71,9 @@ async function getAuthorLink(post) {
 async function getTagsLinks(post) {
   const tags = splitTags(post.tags);
   if (tags.length > 0) {
-    const validatedTags = await validateTags(tags);
+    const [validTags] = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    await Promise.all(validatedTags[0].map(async (tag) => {
+    validTags.forEach((tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
@@ -81,7 +81,8 @@ async function getTagsLinks(post) {
 
       item.append(link);
       list.append(item);
-    }));
+
+    });
     return list;
   }
   return undefined;

--- a/blogs/blocks/post-cards/post-cards.js
+++ b/blogs/blocks/post-cards/post-cards.js
@@ -14,6 +14,7 @@ import {
   buildBlock,
 } from '../../scripts/lib-franklin.js';
 import ffetch from '../../scripts/ffetch.js';
+import { validateTags } from '../../scripts/taxonomy.js';
 
 let pageSize = 7;
 
@@ -67,11 +68,12 @@ async function getAuthorLink(post) {
   return notLink;
 }
 
-function getTagsLinks(post) {
+async function getTagsLinks(post) {
   const tags = splitTags(post.tags);
   if (tags.length > 0) {
+    const validatedTags = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    tags.forEach((tag) => {
+    for (const tag of validatedTags[0]) {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
@@ -79,7 +81,7 @@ function getTagsLinks(post) {
 
       item.append(link);
       list.append(item);
-    });
+    };
 
     return list;
   }
@@ -87,7 +89,7 @@ function getTagsLinks(post) {
   return undefined;
 }
 
-function buildPostCard(post, index) {
+async function buildPostCard(post, index) {
   const classes = ['post-card', 'hidden'];
   const isAnAuthorPage = getMetadata('template') === 'author';
   if (!isAnAuthorPage && index % 7 === 3) {
@@ -158,7 +160,7 @@ function buildPostCard(post, index) {
     }
   });
 
-  const tagsLinks = getTagsLinks(post);
+  const tagsLinks = await getTagsLinks(post);
   if (tagsLinks) {
     postCard.querySelector('.post-card-text').append(tagsLinks);
   }
@@ -182,7 +184,7 @@ async function loadPage(grid) {
   const hasCta = grid.dataset.hasCta === 'true';
   // eslint-disable-next-line no-restricted-syntax
   for await (const post of postsGenerator) {
-    const postCard = buildPostCard(post, hasCta ? counter + 1 : counter);
+    const postCard = await buildPostCard(post, hasCta ? counter + 1 : counter);
     grid.append(postCard);
     counter += 1;
   }

--- a/blogs/blocks/post-cards/post-cards.js
+++ b/blogs/blocks/post-cards/post-cards.js
@@ -73,7 +73,7 @@ async function getTagsLinks(post) {
   if (tags.length > 0) {
     const validatedTags = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    for (const tag of validatedTags[0]) {
+    await Promise.all(validatedTags[0].map(async (tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
@@ -81,11 +81,9 @@ async function getTagsLinks(post) {
 
       item.append(link);
       list.append(item);
-    };
-
+    }));
     return list;
   }
-
   return undefined;
 }
 

--- a/blogs/blocks/post-sidebar/post-sidebar.js
+++ b/blogs/blocks/post-sidebar/post-sidebar.js
@@ -34,14 +34,14 @@ async function buildTags(sidebar) {
     const tagsContainer = createElement('div', 'tags-container');
     const list = createElement('ul', 'tags-list');
     tagsContainer.append(list);
-    for (const tag of validatedTags[0]) {
+    await Promise.all(validatedTags[0].map(async (tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerHTML = `<span class="tag-name">#${tag}</span>`;
       link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag)}`;
       item.append(link);
       list.append(item);
-    };
+    }));
     tagsContainer.id = 'blogs_related_tags';
     sidebar.append(tagsContainer);
   }

--- a/blogs/blocks/post-sidebar/post-sidebar.js
+++ b/blogs/blocks/post-sidebar/post-sidebar.js
@@ -30,18 +30,18 @@ async function buildCta(sidebar) {
 
 async function buildTags(sidebar) {
   if (getMetadata('article:tag') !== '') {
-    const validatedTags = await validateTags(tags);
+    const [validTags] = await validateTags(tags);
     const tagsContainer = createElement('div', 'tags-container');
     const list = createElement('ul', 'tags-list');
     tagsContainer.append(list);
-    await Promise.all(validatedTags[0].map(async (tag) => {
+    validTags.forEach((tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerHTML = `<span class="tag-name">#${tag}</span>`;
       link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag)}`;
       item.append(link);
       list.append(item);
-    }));
+    });
     tagsContainer.id = 'blogs_related_tags';
     sidebar.append(tagsContainer);
   }

--- a/blogs/blocks/post-sidebar/post-sidebar.js
+++ b/blogs/blocks/post-sidebar/post-sidebar.js
@@ -10,6 +10,7 @@ import {
   createElement,
 } from '../../scripts/scripts.js';
 import ffetch from '../../scripts/ffetch.js';
+import { validateTags } from '../../scripts/taxonomy.js';
 
 const socialIcons = ['facebook', 'twitter', 'linkedin', 'email'];
 const tags = getMetadata('article:tag').split(', ');
@@ -27,19 +28,20 @@ async function buildCta(sidebar) {
   }
 }
 
-function buildTags(sidebar) {
+async function buildTags(sidebar) {
   if (getMetadata('article:tag') !== '') {
+    const validatedTags = await validateTags(tags);
     const tagsContainer = createElement('div', 'tags-container');
     const list = createElement('ul', 'tags-list');
     tagsContainer.append(list);
-    tags.forEach((tag) => {
+    for (const tag of validatedTags[0]) {
       const item = createElement('li');
       const link = createElement('a');
       link.innerHTML = `<span class="tag-name">#${tag}</span>`;
       link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag)}`;
       item.append(link);
       list.append(item);
-    });
+    };
     tagsContainer.id = 'blogs_related_tags';
     sidebar.append(tagsContainer);
   }

--- a/blogs/blocks/search-results/search-results.js
+++ b/blogs/blocks/search-results/search-results.js
@@ -36,17 +36,16 @@ async function getAuthorLink(post) {
 async function getTagsLinks(post) {
   const tags = splitTags(post.tags);
   if (tags.length > 0) {
-    const validatedTags = await validateTags(tags);
+    const [validTags] = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    await Promise.all(validatedTags[0].map(async (tag) => {
+    validTags.forEach((tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
       link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag)}`;
-
       item.append(link);
       list.append(item);
-    }));
+    });
     return list;
   }
   return undefined;

--- a/blogs/blocks/search-results/search-results.js
+++ b/blogs/blocks/search-results/search-results.js
@@ -10,6 +10,7 @@ import {
   getPostsFfetch,
 } from '../../scripts/scripts.js';
 import ffetch from '../../scripts/ffetch.js';
+import { validateTags } from '../../scripts/taxonomy.js';
 
 const pageSize = 10;
 const initLoad = pageSize * 2;
@@ -32,11 +33,12 @@ async function getAuthorLink(post) {
   return notLink;
 }
 
-function getTagsLinks(post) {
+async function getTagsLinks(post) {
   const tags = splitTags(post.tags);
   if (tags.length > 0) {
+    const validatedTags = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    tags.forEach((tag) => {
+    for (const tag of validatedTags[0]) {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
@@ -44,7 +46,7 @@ function getTagsLinks(post) {
 
       item.append(link);
       list.append(item);
-    });
+    };
 
     return list;
   }
@@ -75,7 +77,7 @@ function executeSearch(q) {
   return results;
 }
 
-function buildPostCard(post, index) {
+async function buildPostCard(post, index) {
   const classes = ['post-card'];
   if (index >= pageSize) {
     classes.push('hidden');
@@ -119,7 +121,7 @@ function buildPostCard(post, index) {
     }
   });
 
-  const tagsLinks = getTagsLinks(post);
+  const tagsLinks = await getTagsLinks(post);
   if (tagsLinks) {
     postCard.querySelector('.post-card-text').append(tagsLinks);
   }
@@ -139,7 +141,7 @@ export default async function decorate(block) {
   let counter = 0;
   // eslint-disable-next-line no-restricted-syntax
   for await (const post of initResults) {
-    const postCard = buildPostCard(post, counter);
+    const postCard = await buildPostCard(post, counter);
     grid.append(postCard);
     counter += 1;
   }
@@ -174,7 +176,7 @@ export default async function decorate(block) {
       deferredLoaded = true;
       // eslint-disable-next-line no-restricted-syntax
       for await (const post of deferredPosts) {
-        const postCard = buildPostCard(post, counter);
+        const postCard = await buildPostCard(post, counter);
         grid.append(postCard);
         counter += 1;
       }

--- a/blogs/blocks/search-results/search-results.js
+++ b/blogs/blocks/search-results/search-results.js
@@ -38,7 +38,7 @@ async function getTagsLinks(post) {
   if (tags.length > 0) {
     const validatedTags = await validateTags(tags);
     const list = createElement('ul', 'card-tags');
-    for (const tag of validatedTags[0]) {
+    await Promise.all(validatedTags[0].map(async (tag) => {
       const item = createElement('li');
       const link = createElement('a');
       link.innerText = `#${tag}`;
@@ -46,11 +46,9 @@ async function getTagsLinks(post) {
 
       item.append(link);
       list.append(item);
-    };
-
+    }));
     return list;
   }
-
   return undefined;
 }
 

--- a/blogs/blocks/tags/tags.js
+++ b/blogs/blocks/tags/tags.js
@@ -49,13 +49,13 @@ async function getTagsLinks(tags, limit) {
   await Promise.all(validatedTags
     .slice(0, limit > 0 ? limit : validatedTags.length)
     .map(async (tag) => {
-    const item = createElement('li');
-    const link = createElement('a');
-    link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;
-    link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag.tag)}`;
-    item.append(link);
-    list.append(item);
-  }));
+      const item = createElement('li');
+      const link = createElement('a');
+      link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;
+      link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag.tag)}`;
+      item.append(link);
+      list.append(item);
+    }));
   return list;
 }
 

--- a/blogs/blocks/tags/tags.js
+++ b/blogs/blocks/tags/tags.js
@@ -6,6 +6,7 @@ import {
   filterPosts,
 } from '../../scripts/scripts.js';
 import { readBlockConfig } from '../../scripts/lib-franklin.js';
+import { validateTagObjs } from '../../scripts/taxonomy.js';
 
 function buildSearch(block) {
   const wrapper = createElement('div', 'find-tag');
@@ -42,18 +43,17 @@ function buildSearch(block) {
   return wrapper;
 }
 
-function getTagsLinks(tags, limit) {
+async function getTagsLinks(tags, limit) {
   const list = createElement('ul', 'tags-list');
-  tags.slice(0, limit > 0 ? limit : tags.length).forEach((tag) => {
+  const validatedTags = await validateTagObjs(tags);
+  await Promise.all(validatedTags.slice(0, limit > 0 ? limit : validatedTags.length).map(async (tag) => {
     const item = createElement('li');
     const link = createElement('a');
     link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;
     link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag.tag)}`;
-
     item.append(link);
     list.append(item);
-  });
-
+  }));
   return list;
 }
 
@@ -107,7 +107,7 @@ async function loadTags(block, isAll) {
   });
   tagsAsArray.sort((a, b) => b.count - a.count);
   block.innerHTML = '';
-  block.append(getTagsLinks(tagsAsArray, isAll ? -1 : 15));
+  block.append(await getTagsLinks(tagsAsArray, isAll ? -1 : 15));
   if (isAll) {
     block.prepend(buildSearch(block));
   }

--- a/blogs/blocks/tags/tags.js
+++ b/blogs/blocks/tags/tags.js
@@ -46,7 +46,9 @@ function buildSearch(block) {
 async function getTagsLinks(tags, limit) {
   const list = createElement('ul', 'tags-list');
   const validatedTags = await validateTagObjs(tags);
-  await Promise.all(validatedTags.slice(0, limit > 0 ? limit : validatedTags.length).map(async (tag) => {
+  await Promise.all(validatedTags
+    .slice(0, limit > 0 ? limit : validatedTags.length)
+    .map(async (tag) => {
     const item = createElement('li');
     const link = createElement('a');
     link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;

--- a/blogs/blocks/tags/tags.js
+++ b/blogs/blocks/tags/tags.js
@@ -46,16 +46,14 @@ function buildSearch(block) {
 async function getTagsLinks(tags, limit) {
   const list = createElement('ul', 'tags-list');
   const validatedTags = await validateTagObjs(tags);
-  await Promise.all(validatedTags
-    .slice(0, limit > 0 ? limit : validatedTags.length)
-    .map(async (tag) => {
-      const item = createElement('li');
-      const link = createElement('a');
-      link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;
-      link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag.tag)}`;
-      item.append(link);
-      list.append(item);
-    }));
+  validatedTags.slice(0, limit).forEach((tag) => {
+    const item = createElement('li');
+    const link = createElement('a');
+    link.innerHTML = `<span class="tag-name">#${tag.tag}</span><span class="tag-count">${tag.count}</span>`;
+    link.href = `/blogs/tag-matches?tag=${encodeURIComponent(tag.tag)}`;
+    item.append(link);
+    list.append(item);
+  });
   return list;
 }
 

--- a/blogs/scripts/taxonomy.js
+++ b/blogs/scripts/taxonomy.js
@@ -72,10 +72,12 @@ export async function validateTags(tagsArray) {
       if (allowedTags.includes(toClassName(tag))) {
         validTags.push(tag);
       } else {
+        console.warn('Tag warning:', tag); // warn for tag cleanup
         invalidTags.push(tag);
       }
     });
-    return [validTags, invalidTags];
+    return [tagsArray, invalidTags]; // return original tags for now
+    // return [validTags, invalidTags];
   } catch (e) {
     // console.log('Error:', e);
   }

--- a/blogs/scripts/taxonomy.js
+++ b/blogs/scripts/taxonomy.js
@@ -48,7 +48,7 @@ export async function validateTagObjs(tagsObjArray) {
     tagsObjArray.forEach((obj) => {
       if (allowedTags.includes(toClassName(obj.tag))) {
         result.push(obj);
-      }      
+      }
     });
     return result;
   } catch (e) {

--- a/blogs/scripts/taxonomy.js
+++ b/blogs/scripts/taxonomy.js
@@ -1,0 +1,84 @@
+import { toClassName } from './lib-franklin.js';
+
+/**
+ * Find the second-level list items and put them into a single array.
+ * @returns {Array} An array of tag strings
+ */
+async function getTags(ul) {
+  const tagList = ul.querySelectorAll('ul li ul li');
+  const tagArray = [...tagList];
+  const textArray = tagArray.map((li) => toClassName(li.textContent));
+  return textArray;
+}
+
+/**
+ * Retrieve HTML from tags.docx.
+ * @returns {Array} An array of tag strings
+ */
+async function getFranklinTags() {
+  let resp;
+  try {
+    // Fetch the HTML content of the webpage
+    resp = await fetch(`${origin}/blogs/tags.plain.html`);
+    if (resp && resp.ok) {
+      const text = await resp.text();
+      const tempElement = document.createElement('div');
+      tempElement.innerHTML = text;
+      // Get the root <ul> element
+      const rootUlElement = tempElement.querySelector('ul');
+      // Create the JavaScript array from the nested <ul>
+      const result = await getTags(rootUlElement);
+      return result;
+    }
+  } catch (e) {
+    // console.log('Error:', e);
+  }
+  return null;
+}
+
+/**
+ * Validate an array of tag objects against a source.
+ * @param {Array} tagObjArray The object array to validate.
+ * @returns {Array} Array containing the valid tag objects.
+ */
+export async function validateTagObjs(tagsObjArray) {
+  try {
+    const allowedTags = await getFranklinTags();
+    let result = [];
+    await Promise.all(tagsObjArray.map(async (obj) => {
+      if (allowedTags.includes(toClassName(obj.tag))) {
+        result.push(obj);
+      }
+    }));
+    return result;
+  } catch (e) {
+    // console.log('Error:', e);
+  }
+  return null;
+}
+
+/**
+ * Validate an array of tag strings against a source.
+ * @param {String} tagArray The string array to validate.
+ * @returns {Array} Array containing two arrays. The first array being only the valid tags,
+ * the second one being the tags that are invalid
+ */
+export async function validateTags(tagsArray) {
+  try {
+    const allowedTags = await getFranklinTags();
+    let validTags = [];
+    let invalidTags = [];
+
+    await Promise.all(tagsArray.map(async (tag) => {
+      if (allowedTags.includes(toClassName(tag))) {
+        validTags.push(tag);
+      } else {
+        invalidTags.push(tag);
+      }
+    }));
+    return [validTags, invalidTags];
+  } catch (e) {
+    // console.log('Error:', e);
+  }
+  return null;
+}

--- a/blogs/scripts/taxonomy.js
+++ b/blogs/scripts/taxonomy.js
@@ -45,11 +45,11 @@ export async function validateTagObjs(tagsObjArray) {
   try {
     const allowedTags = await getFranklinTags();
     const result = [];
-    await Promise.all(tagsObjArray.map(async (obj) => {
+    tagsObjArray.forEach((obj) => {
       if (allowedTags.includes(toClassName(obj.tag))) {
         result.push(obj);
-      }
-    }));
+      }      
+    });
     return result;
   } catch (e) {
     // console.log('Error:', e);
@@ -68,14 +68,13 @@ export async function validateTags(tagsArray) {
     const allowedTags = await getFranklinTags();
     const validTags = [];
     const invalidTags = [];
-
-    await Promise.all(tagsArray.map(async (tag) => {
+    tagsArray.forEach((tag) => {
       if (allowedTags.includes(toClassName(tag))) {
         validTags.push(tag);
       } else {
         invalidTags.push(tag);
       }
-    }));
+    });
     return [validTags, invalidTags];
   } catch (e) {
     // console.log('Error:', e);

--- a/blogs/scripts/taxonomy.js
+++ b/blogs/scripts/taxonomy.js
@@ -44,7 +44,7 @@ async function getFranklinTags() {
 export async function validateTagObjs(tagsObjArray) {
   try {
     const allowedTags = await getFranklinTags();
-    let result = [];
+    const result = [];
     await Promise.all(tagsObjArray.map(async (obj) => {
       if (allowedTags.includes(toClassName(obj.tag))) {
         result.push(obj);
@@ -66,8 +66,8 @@ export async function validateTagObjs(tagsObjArray) {
 export async function validateTags(tagsArray) {
   try {
     const allowedTags = await getFranklinTags();
-    let validTags = [];
-    let invalidTags = [];
+    const validTags = [];
+    const invalidTags = [];
 
     await Promise.all(tagsArray.map(async (tag) => {
       if (allowedTags.includes(toClassName(tag))) {


### PR DESCRIPTION
This PR applies only to Franklin tags. Next PR will use AEM tags.

Fix #77 

Test URLs:
**Post-Cards & Tags**
- Before: https://main--blogs-keysight--hlxsites.hlx.live/blogs/
- After: https://validate-tags--blogs-keysight--hlxsites.hlx.live/blogs/

**Post-Sidebar**
- Before: https://main--blogs-keysight--hlxsites.hlx.live/blogs/tech/software-testing/2023/6/6/digital-transformation-in-education-blog
- After: https://validate-tags--blogs-keysight--hlxsites.hlx.live/blogs/tech/software-testing/2023/6/6/digital-transformation-in-education-blog

**Search**
- Before: https://main--blogs-keysight--hlxsites.hlx.live/blogs/search?q=testing
- After: https://validate-tags--blogs-keysight--hlxsites.hlx.live/blogs/search?q=testing
