### PR TITLE
fix: migrate to new fullscreen sidekick library

### DIFF
--- a/blogs/blocks/featured-posts/featured-posts.js
+++ b/blogs/blocks/featured-posts/featured-posts.js
@@ -1,6 +1,6 @@
 import ffetch from '../../scripts/ffetch.js';
 import { getMetadataJson } from '../../scripts/scripts.js';
-import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, getMetadata, getOrigin } from '../../scripts/lib-franklin.js';
 
 function buildPost(isPlaceholder, entry) {
   return `
@@ -20,7 +20,7 @@ function buildPost(isPlaceholder, entry) {
  * @param {Element} block The featured posts block element
  */
 export default async function decorate(block) {
-  const indexUrl = new URL('/blogs/query-index.json', window.location.origin);
+  const indexUrl = new URL('/blogs/query-index.json', getOrigin());
   const postsGrid = block.querySelector('div');
   postsGrid.classList.add('featured-posts-grid');
 

--- a/blogs/blocks/post-cards/post-cards.js
+++ b/blogs/blocks/post-cards/post-cards.js
@@ -12,6 +12,7 @@ import {
   decorateBlock,
   loadBlock,
   buildBlock,
+  getOrigin,
 } from '../../scripts/lib-franklin.js';
 import ffetch from '../../scripts/ffetch.js';
 
@@ -227,7 +228,7 @@ async function loadPostCards(block) {
   // post a message indicating cards are loaded, this triggers the tags block to load
   // see comment there for more details
   block.dataset.postsLoaded = 'true';
-  window.postMessage({ postCardsLoaded: true }, window.location.origin);
+  window.postMessage({ postCardsLoaded: true }, getOrigin());
 }
 
 /**

--- a/blogs/blocks/tags/tags.js
+++ b/blogs/blocks/tags/tags.js
@@ -5,7 +5,7 @@ import {
   getPostsFfetch,
   filterPosts,
 } from '../../scripts/scripts.js';
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
+import { getOrigin, readBlockConfig } from '../../scripts/lib-franklin.js';
 
 function buildSearch(block) {
   const wrapper = createElement('div', 'find-tag');
@@ -139,7 +139,7 @@ export default async function decorate(block) {
       message would never be received.
     */
     window.addEventListener('message', (msg) => {
-      if (msg.origin === window.location.origin && msg.data && msg.data.postCardsLoaded) {
+      if (msg.origin === getOrigin() && msg.data && msg.data.postCardsLoaded) {
         loadTags(block, isAll);
       }
     });

--- a/blogs/rss/feed.xml
+++ b/blogs/rss/feed.xml
@@ -2,10 +2,18 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://www.keysight.com/blogs</id>
     <title>Keysight Blogs</title>
-    <updated>2023-06-07T00:00:00.000Z</updated>
+    <updated>2023-06-09T00:00:00.000Z</updated>
     <generator>News feed generator (GitHub action)</generator>
     <link rel="alternate" href="https://www.keysight.com/blogs"/>
     <subtitle>Keysight Blogs</subtitle>
+    <entry>
+        <title type="html"><![CDATA[Digital Twins in Engineering: Evolutionary or Revolutionary?]]></title>
+        <id>https://www.keysight.com/blogs/blogs/tech/sim-des/2023/06/09/digital-twins-engineering-revolutionary-evolutionary</id>
+        <link href="https://www.keysight.com/blogs/blogs/tech/sim-des/2023/06/09/digital-twins-engineering-revolutionary-evolutionary"/>
+        <updated>2023-06-09T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[Are digital twins going to change the world? If you’re an engineer, there’s a good chance you’ll be using them in the next five years — if you aren’t already.]]></content>
+        <published>2023-06-09T00:00:00.000Z</published>
+    </entry>
     <entry>
         <title type="html"><![CDATA[Vital Signs: The Rise of Automated Healthcare Software Testing]]></title>
         <id>https://www.keysight.com/blogs/blogs/keys/thought-leadership/2023/06/07/the-rise-of-automated-healthcare-software-testing</id>

--- a/blogs/rss/feed.xml
+++ b/blogs/rss/feed.xml
@@ -16,14 +16,6 @@
     </entry>
     <entry>
         <title type="html"><![CDATA[Find Out What the Tech Future Means for You]]></title>
-        <id>https://www.keysight.com/blogs/blogs/keys/thought-leadership/2023/06/future-av-5g-6g-ntn-digital-healthcare-keysight-world-innovate-2023</id>
-        <link href="https://www.keysight.com/blogs/blogs/keys/thought-leadership/2023/06/future-av-5g-6g-ntn-digital-healthcare-keysight-world-innovate-2023"/>
-        <updated>2023-06-06T00:00:00.000Z</updated>
-        <content type="html"><![CDATA[Virtual, expert-led sessions cover engineering in emerging technologies, like the 5G and 6G metaverse, software-defined vehicles, extraterrestrial communications, and digital healthcare, at Keysight World: Innovate.]]></content>
-        <published>2023-06-06T00:00:00.000Z</published>
-    </entry>
-    <entry>
-        <title type="html"><![CDATA[Find Out What the Tech Future Means for You]]></title>
         <id>https://www.keysight.com/blogs/blogs/keys/culture/2023/06/07/future-av-5g-6g-ntn-digital-healthcare-keysight-world-innovate-2023</id>
         <link href="https://www.keysight.com/blogs/blogs/keys/culture/2023/06/07/future-av-5g-6g-ntn-digital-healthcare-keysight-world-innovate-2023"/>
         <updated>2023-06-06T00:00:00.000Z</updated>

--- a/blogs/scripts/lib-franklin.js
+++ b/blogs/scripts/lib-franklin.js
@@ -391,13 +391,35 @@ export async function loadBlocks(main) {
 }
 
 /**
+ * Returns the true origin of the current page in the browser.
+ * If the page is running in a iframe with srcdoc, the ancestor origin is returned.
+ * @returns {String} The true origin
+ */
+export function getOrigin() {
+  return window.location.href === 'about:srcdoc' ? window.parent.location.origin : window.location.origin;
+}
+
+/**
+ * Returns the true of the current page in the browser.
+ * If the page is running in a iframe with srcdoc,
+ * the ancestor origin + the path query param is returned.
+ * @returns {String} The href of the current page or the href of the block running in the library
+ */
+export function getHref() {
+  if (window.location.href !== 'about:srcdoc') return window.location.href;
+
+  const urlParams = new URLSearchParams(window.parent.location.search);
+  return `${window.parent.location.origin}${urlParams.get('path')}`;
+}
+
+/**
  * Returns a picture element with webp and fallbacks
  * @param {string} src The image URL
  * @param {boolean} eager load image eager
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
  */
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
-  const url = new URL(src, window.location.href);
+  const url = new URL(src, getHref());
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -16,9 +16,7 @@
       "environments": [
         "edit"
       ],
-      "isPalette": true,
-      "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 398px; width: 360px;",
-      "url": "https://hlx.live/tools/sidekick/library?base=https://main--blogs-keysight--hlxsites.hlx.live/block-library/library.json&autoblocks=https://main--blogs-keysight--hlxsites.hlx.page/tools/sidekick/library/plugins/autoblocks/autoblocks.js&templates=https://block-library-templates--blogs-keysight--hlxsites.hlx.page/tools/sidekick/library/plugins/templates/templates.js",
+      "url": "/tools/sidekick/library/library.html",
       "includePaths": [
         "**.docx**"
       ]

--- a/tools/sidekick/library/library.html
+++ b/tools/sidekick/library/library.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="Description" content="AEM Sidekick Library" />
+    <meta name="robots" content="noindex" />
+    <base href="/" />
+
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: sans-serif;
+        background-color: #ededed;
+        height: 100%;
+      }
+
+      helix-sidekick { display: none }
+    </style>
+    <title>Sidekick Library</title>
+  </head>
+
+  <body>
+    <script
+      type="module"
+      src="https://www.hlx.live/tools/sidekick/library/index.js"
+    ></script>
+    <script>
+      const library = document.createElement('sidekick-library')
+      library.config = {
+        base: '/block-library/library.json',
+        autoblocks: '/tools/sidekick/library/plugins/autoblocks/autoblocks.js',
+        templates: '/tools/sidekick/library/plugins/templates/templates.js',
+        placeholders: '/tools/sidekick/plugins/placeholders/placeholders.js'
+      }
+
+      document.body.prepend(library)
+    </script>
+  </body>
+</html>

--- a/tools/sidekick/library/library.html
+++ b/tools/sidekick/library/library.html
@@ -35,8 +35,7 @@
       library.config = {
         base: '/block-library/library.json',
         autoblocks: '/tools/sidekick/library/plugins/autoblocks/autoblocks.js',
-        templates: '/tools/sidekick/library/plugins/templates/templates.js',
-        placeholders: '/tools/sidekick/plugins/placeholders/placeholders.js'
+        templates: '/tools/sidekick/library/plugins/templates/templates.js'
       }
 
       document.body.prepend(library)


### PR DESCRIPTION
Do not merge until https://github.com/adobe/helix-website/pull/275 is merged
This PR migrates the blogs-keysight sidekick library to the new full screen version.

@shsteimer One merged you will need to go into the block documents and separate each variation with a section delimiter to have it appear correctly in the library.

Test URLs:

Before: https://main--blogs-keysight--hlxsites.hlx.page/
After: https://sidekick-library-migration--blogs-keysight--hlxsites.hlx.page/
